### PR TITLE
Basic features: sample data, basket and compare commands

### DIFF
--- a/bot/handlers.py
+++ b/bot/handlers.py
@@ -3,26 +3,64 @@
 from aiogram import Dispatcher, types
 from aiogram.filters import Command
 
+# Import helper functions from sample_data
+from bot.utils.sample_data import compare_prices, get_cheapest_basket
 
 async def start_cmd(message: types.Message) -> None:
     """Handle /start command."""
-    await message.answer("Welcome to Sparly! Use /prefs to set your preferences.")
-
+    # Send a greeting message and instructions for the user.
+    await message.answer(
+        "Welcome to Sparly! Use /prefs to set your preferences. "
+        "Use /basket to calculate the cheapest basket or /compare <product> to compare prices."
+    )
 
 async def prefs_cmd(message: types.Message) -> None:
     """Handle /prefs command."""
+    # Placeholder for preferences handling logic (language, radius, categories, etc.)
     await message.answer("Preferences command placeholder.")
-
 
 async def basket_cmd(message: types.Message) -> None:
     """Handle /basket command."""
-    await message.answer(
-        "Please send your basket items separated by commas."
-    )
+    # If the user only sends '/basket' without items, ask them to provide items.
+    args = message.text.split(maxsplit=1)
+    if len(args) < 2:
+        await message.answer("Please send your basket items separated by commas.")
+        return
+    items_raw = args[1]
+    items = [item.strip() for item in items_raw.split(",") if item.strip()]
+    if not items:
+        await message.answer("Please provide at least one item.")
+        return
+    totals = get_cheapest_basket(items)
+    if not totals:
+        await message.answer("No data found for your items.")
+        return
+    # Build a response listing each store and total price
+    lines = [f"{store}: {total:.2f}\u20ac" for store, total in sorted(totals.items(), key=lambda x: x[1])]
+    text = "Cheapest basket options:\n" + "\n".join(lines)
+    await message.answer(text)
 
+async def compare_cmd(message: types.Message) -> None:
+    """Handle /compare command to compare prices for a single product."""
+    args = message.text.split(maxsplit=1)
+    if len(args) < 2:
+        await message.answer("Please provide a product name, e.g. /compare eggs")
+        return
+    product = args[1].strip()
+    offers = compare_prices(product)
+    if not offers:
+        await message.answer(f"No price data found for {product}.")
+        return
+    lines = [
+        f"{offer['chain']} {offer['store_name']}: {offer['price']:.2f}\u20ac"
+        for offer in offers
+    ]
+    text = f"Price comparison for {product}:\n" + "\n".join(lines)
+    await message.answer(text)
 
 def register_handlers(dp: Dispatcher) -> None:
     """Register command handlers with the dispatcher."""
     dp.message.register(start_cmd, Command("start"))
     dp.message.register(prefs_cmd, Command("prefs"))
     dp.message.register(basket_cmd, Command("basket"))
+    dp.message.register(compare_cmd, Command("compare"))

--- a/bot/utils/sample_data.py
+++ b/bot/utils/sample_data.py
@@ -1,0 +1,106 @@
+# Sample data and helper functions for Sparly bot demonstration.
+
+from typing import List, Dict
+
+# Sample discounts data: list of dictionaries representing discount offers.
+SAMPLE_DISCOUNTS: List[Dict] = [
+    {
+        "store_id": 1,
+        "chain": "Lidl",
+        "name": "Lidl München",
+        "lat": 48.1351,
+        "lon": 11.5820,
+        "product_name": "Eggs 10pcs",
+        "price": 1.19,
+        "price_old": 1.49,
+        "valid_until": "2025-08-10",
+    },
+    {
+        "store_id": 2,
+        "chain": "REWE",
+        "name": "REWE City",
+        "lat": 48.1351,
+        "lon": 11.5820,
+        "product_name": "Eggs 10pcs",
+        "price": 1.29,
+        "price_old": 1.59,
+        "valid_until": "2025-08-11",
+    },
+    {
+        "store_id": 3,
+        "chain": "Lidl",
+        "name": "Lidl München",
+        "lat": 48.1351,
+        "lon": 11.5820,
+        "product_name": "Milk 1L",
+        "price": 0.79,
+        "price_old": 0.99,
+        "valid_until": "2025-08-09",
+    },
+    {
+        "store_id": 4,
+        "chain": "REWE",
+        "name": "REWE City",
+        "lat": 48.1351,
+        "lon": 11.5820,
+        "product_name": "Butter 250g",
+        "price": 1.49,
+        "price_old": 1.79,
+        "valid_until": "2025-08-12",
+    },
+]
+
+
+def get_discounts() -> List[Dict]:
+    """Return sample discount offers."""
+    return SAMPLE_DISCOUNTS
+
+
+def compare_prices(product_name: str) -> List[Dict]:
+    """
+    Return list of offers for a given product name across stores.
+
+    Args:
+        product_name: name of the product to search for.
+
+    Returns:
+        A list of sample discounts matching the product_name (case-insensitive).
+    """
+    product_name_lower = product_name.lower()
+    return [
+        d for d in SAMPLE_DISCOUNTS
+        if product_name_lower in d["product_name"].lower()
+    ]
+
+
+def get_cheapest_basket(items: List[str]) -> Dict[str, float]:
+    """
+    Compute cheapest total price for the given items across stores.
+
+    For demonstration purposes this function sums the lowest price per item
+    from the SAMPLE_DISCOUNTS dataset without considering store grouping.
+
+    Args:
+        items: list of product names.
+
+    Returns:
+        Dictionary with total price per store (chain-name) for demonstration.
+    """
+    # Build a mapping of product -> cheapest offer
+    cheapest: Dict[str, Dict] = {}
+    for d in SAMPLE_DISCOUNTS:
+        key = d["product_name"].lower()
+        if key not in cheapest or d["price"] < cheapest[key]["price"]:
+            cheapest[key] = d
+
+    # Sum cheapest prices
+    total_per_store: Dict[str, float] = {}
+    for item in items:
+        item_lower = item.lower()
+        # find first matching item (simplified)
+        for d_key, offer in cheapest.items():
+            if item_lower in d_key:
+                store = offer["name"]
+                total_per_store[store] = total_per_store.get(store, 0.0) + offer["price"]
+                break
+    return total_per_store


### PR DESCRIPTION
This PR adds a sample_data module with sample discounts and implements /basket and /compare commands in handlers.py to demonstrate cheapest basket and product price comparison. It also updates the /start message. Future work includes implementing real scrapers and database integration.